### PR TITLE
Add menu flow with persistent player name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
   <title>Retro Platformer — 3 Levels</title>
   <style>
     body {margin:0;background:#000;color:#fff;font-family:monospace;display:flex;flex-direction:column;align-items:center;}
+    .hidden {display:none !important;}
     .hud {margin:10px;}
     canvas {image-rendering:pixelated;border:2px solid #fff;background:#111;}
     button {margin-top:10px;padding:5px 10px;font-family:monospace;}
@@ -24,31 +25,77 @@
     .leaderboard-list {text-align:left;margin:0 auto;padding-left:20px;}
     .leaderboard-list li {margin-bottom:4px;}
     .leaderboard-list li.highlight {color:#0ff;font-weight:bold;}
+    .fullscreen-overlay {position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:#000;color:#fff;fon
+t-family:monospace;z-index:20;}
+    .menu-panel {border:2px solid #fff;background:#111;padding:20px;width:320px;text-align:center;display:flex;flex-direction:colu
+mn;gap:12px;}
+    .menu-panel h1 {margin:0;font-size:24px;letter-spacing:3px;text-transform:uppercase;}
+    .menu-panel p {margin:0;font-size:14px;}
+    .menu-panel form {display:flex;flex-direction:column;gap:8px;}
+    .menu-panel label {font-size:12px;text-transform:uppercase;letter-spacing:1px;}
+    .menu-panel input {padding:6px;font-family:monospace;background:#000;border:1px solid #fff;color:#fff;}
+    .menu-buttons {display:flex;flex-direction:column;gap:8px;}
+    .menu-buttons button {padding:8px 12px;font-family:monospace;letter-spacing:1px;margin-top:0;}
+    .completion-content .submit-info {font-size:12px;text-transform:uppercase;letter-spacing:1px;color:#0ff;}
   </style>
 </head>
 <body>
-  <div class="hud">
+  <div id="welcomeScreen" class="fullscreen-overlay hidden">
+    <div class="menu-panel">
+      <h1>Welcome</h1>
+      <p>Enter your name to begin</p>
+      <form id="welcomeForm">
+        <label for="welcomeName">Player Name</label>
+        <input id="welcomeName" type="text" maxlength="16" autocomplete="name" placeholder="Player" />
+        <button type="submit">Continue</button>
+      </form>
+    </div>
+  </div>
+
+  <div id="mainMenu" class="fullscreen-overlay hidden">
+    <div class="menu-panel">
+      <h1>PLATFORMER</h1>
+      <p>Current Name: <span id="menuPlayerName">Player</span></p>
+      <div class="menu-buttons">
+        <button id="playBtn" type="button">Play</button>
+        <button id="settingsBtn" type="button">Settings</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="settingsMenu" class="fullscreen-overlay hidden">
+    <div class="menu-panel">
+      <h1>Settings</h1>
+      <form id="settingsForm">
+        <label for="settingsName">Player Name</label>
+        <input id="settingsName" type="text" maxlength="16" autocomplete="name" />
+        <div class="menu-buttons">
+          <button type="submit">Confirm</button>
+          <button type="button" id="settingsCancel">Cancel</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div id="hud" class="hud hidden">
     <span id="levelText">Level: 1 / 3</span> |
     <span id="timeText">00:00.000</span>
     <button id="restartBtn">Restart</button>
   </div>
-  <div style="position:relative;">
+  <div id="gameWrapper" class="hidden" style="position:relative;">
     <canvas id="game" width="900" height="520"></canvas>
     <div id="overlay" class="overlay"></div>
     <div id="completionMenu">
       <div class="completion-content">
         <h2>Complete!</h2>
         <p>Your time: <span id="finalTime">00:00.000</span></p>
-        <form id="scoreForm">
-          <label for="playerName">Enter your name</label>
-          <input id="playerName" name="playerName" type="text" maxlength="16" autocomplete="name" placeholder="Player" />
-          <button type="submit">Submit Score</button>
-        </form>
+        <div class="submit-info">Submitting as: <span id="scorePlayerName">Player</span></div>
+        <button id="submitScoreBtn" type="button">Submit Score</button>
         <div>
           <h3>Top 5</h3>
           <ol id="leaderboard" class="leaderboard-list"></ol>
         </div>
-        <button id="menuRestartBtn" type="button">Restart</button>
+        <button id="menuRestartBtn" type="button">Back to Menu</button>
       </div>
     </div>
   </div>
@@ -76,11 +123,14 @@
     ];
 
     let levelIdx=0,firstMoveArmed=true,timerStart=null,timerEnd=null,scoreSubmitted=false,highlightedEntry=null;
+    let appState='welcome';
+    let animationId=null;
 
     const keys=new Set();
     const startKeys=new Set(['ArrowLeft','ArrowRight','KeyA','KeyD','Space','KeyW','ArrowUp']);
 
     window.addEventListener('keydown',e=>{
+      if(appState!=='game')return;
       keys.add(e.code);
       if(firstMoveArmed&&levelIdx===0&&startKeys.has(e.code)){
         firstMoveArmed=false;timerStart=performance.now();timerEnd=null;overlay("");
@@ -99,30 +149,56 @@
         }
       }
     });
-    window.addEventListener('keyup',e=>keys.delete(e.code));
+    window.addEventListener('keyup',e=>{
+      if(appState!=='game')return;
+      keys.delete(e.code);
+    });
 
     const timeText=document.getElementById('timeText');
     const levelText=document.getElementById('levelText');
     const overlayEl=document.getElementById('overlay');
     const completionMenu=document.getElementById('completionMenu');
     const finalTimeEl=document.getElementById('finalTime');
-    const scoreForm=document.getElementById('scoreForm');
-    const playerNameInput=document.getElementById('playerName');
-    const menuRestartBtn=document.getElementById('menuRestartBtn');
     const leaderboardEl=document.getElementById('leaderboard');
-    const submitBtn=scoreForm?scoreForm.querySelector('button[type="submit"]'):null;
+    const submitScoreBtn=document.getElementById('submitScoreBtn');
+    const scorePlayerNameEl=document.getElementById('scorePlayerName');
+    const menuRestartBtn=document.getElementById('menuRestartBtn');
+    const restartBtn=document.getElementById('restartBtn');
+    const hud=document.getElementById('hud');
+    const gameWrapper=document.getElementById('gameWrapper');
+    const welcomeScreen=document.getElementById('welcomeScreen');
+    const mainMenu=document.getElementById('mainMenu');
+    const settingsMenu=document.getElementById('settingsMenu');
+    const welcomeForm=document.getElementById('welcomeForm');
+    const welcomeNameInput=document.getElementById('welcomeName');
+    const playBtn=document.getElementById('playBtn');
+    const settingsBtn=document.getElementById('settingsBtn');
+    const settingsForm=document.getElementById('settingsForm');
+    const settingsNameInput=document.getElementById('settingsName');
+    const settingsCancelBtn=document.getElementById('settingsCancel');
+    const menuPlayerNameEl=document.getElementById('menuPlayerName');
 
     function fmt(ms){if(ms==null)return'00:00.000';const t=Math.floor(ms);const m=Math.floor(t/60000);const s=Math.floor((t%60000)/1000);const ms3=String(t%1000).padStart(3,'0');return`${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}.${ms3}`;}
     function updateTimerUI(){const t=timerEnd??(timerStart?performance.now()-timerStart:0);timeText.textContent=fmt(t);} 
     function overlay(msg){if(msg){overlayEl.textContent=msg;overlayEl.classList.remove('hidden');}else{overlayEl.textContent='';overlayEl.classList.add('hidden');}}
 
     const LB_KEY='retroPlatformerLB';
+    const NAME_KEY='retroPlatformerName';
     function loadLB(){try{return JSON.parse(localStorage.getItem(LB_KEY))||[]}catch{return[]}}
     function saveLB(a){localStorage.setItem(LB_KEY,JSON.stringify(a));}
+    function loadName(){try{return localStorage.getItem(NAME_KEY)||'';}catch{return'';}}
+    function saveNameValue(name){try{localStorage.setItem(NAME_KEY,name);}catch{}}
+    function sanitizeName(value){return(value||'').trim().slice(0,16);}
+    const storedName=sanitizeName(loadName());
+    const hadStoredName=!!storedName;
+    let currentPlayerName=storedName||'Player';
+    function updateNameDisplays(){if(menuPlayerNameEl)menuPlayerNameEl.textContent=currentPlayerName;if(scorePlayerNameEl)scorePlayerNameEl.textContent=currentPlayerName;}
+    function setPlayerName(value){const sanitized=sanitizeName(value);currentPlayerName=sanitized||'Player';saveNameValue(currentPlayerName);updateNameDisplays();}
     function pushTime(ms,name){
-      if(!name)return false;
+      const cleanName=sanitizeName(name)||'Player';
+      if(!cleanName)return false;
       const arr=loadLB();
-      const entry={ms,name};
+      const entry={ms,name:cleanName};
       arr.push(entry);
       arr.sort((a,b)=>a.ms-b.ms);
       let kept=true;
@@ -150,16 +226,14 @@
     }
     function showCompletionMenu(){
       if(timerEnd==null)return;
-      if(scoreForm)scoreForm.reset();
       finalTimeEl.textContent=fmt(timerEnd);
+      updateNameDisplays();
       renderLB();
       completionMenu.classList.add('active');
-      if(submitBtn)submitBtn.disabled=scoreSubmitted;
-      if(playerNameInput) setTimeout(()=>playerNameInput.focus(),0);
+      if(submitScoreBtn)submitScoreBtn.disabled=scoreSubmitted;
     }
     function hideCompletionMenu(){
       completionMenu.classList.remove('active');
-      if(scoreForm)scoreForm.reset();
     }
 
     function currentLevel(){return levels[levelIdx];}
@@ -178,7 +252,7 @@
         timerEnd=null;
         scoreSubmitted=false;
         highlightedEntry=null;
-        if(submitBtn)submitBtn.disabled=false;
+        if(submitScoreBtn)submitScoreBtn.disabled=false;
         overlay('PRESS ANY MOVE KEY TO START');
       }else overlay('');
     }
@@ -242,7 +316,7 @@
       for(const p of particles){p.y+=2;p.alpha-=0.05;}while(particles.length&&particles[0].alpha<=0)particles.shift();
       for(const t of triangles){t.x+=t.dx;t.y+=t.dy;t.alpha-=0.04;}while(triangles.length&&triangles[0].alpha<=0)triangles.shift();
 
-      draw();updateTimerUI();requestAnimationFrame(tick);
+      draw();updateTimerUI();
     }
 
     function draw(){
@@ -251,7 +325,7 @@
       for(const r of currentLevel().plats){ctx.fillStyle=r.color;ctx.fillRect(r.x,r.y,r.w,r.h);} 
       ctx.fillStyle='red';for(const d of currentLevel().dots)if(!d.collected)ctx.fillRect(d.x-3,d.y-3,6,6);
       ctx.fillStyle='#fff';ctx.fillRect(player.x,player.y,player.w,player.h);
-      for(const p of particles){ctx.fillStyle=`rgba(255,255,255,${p.alpha})`;ctx.fillRect(p.x-p.w/2,p.y,p.w,2);}
+      for(const p of particles){ctx.fillStyle=`rgba(255,255,255,${p.alpha})`;ctx.fillRect(p.x-p.w/2,p.y,p.w,2);} 
       for(const t of triangles){
         ctx.fillStyle=`rgba(85,85,85,${t.alpha})`;
         ctx.beginPath();
@@ -263,20 +337,104 @@
       }
     }
 
-    document.getElementById('restartBtn').addEventListener('click',()=>{loadLevel(0);});
-    scoreForm.addEventListener('submit',e=>{
-      e.preventDefault();
+    function clearInputs(){keys.clear();}
+    function updateVisibility(){
+      hud.classList.toggle('hidden',appState!=='game');
+      gameWrapper.classList.toggle('hidden',appState!=='game');
+      welcomeScreen.classList.toggle('hidden',appState!=='welcome');
+      mainMenu.classList.toggle('hidden',appState!=='menu');
+      settingsMenu.classList.toggle('hidden',appState!=='settings');
+    }
+    function stopLoop(){
+      if(animationId!=null){cancelAnimationFrame(animationId);animationId=null;}
+    }
+    function startLoop(){
+      stopLoop();
+      const frame=()=>{
+        if(appState!=='game'){animationId=null;return;}
+        tick();
+        animationId=requestAnimationFrame(frame);
+      };
+      animationId=requestAnimationFrame(frame);
+    }
+    function showWelcome(){
+      appState='welcome';
+      updateVisibility();
+      stopLoop();
+      clearInputs();
+      hideCompletionMenu();
+      overlay('');
+      if(welcomeForm)welcomeForm.reset();
+      if(welcomeNameInput)setTimeout(()=>welcomeNameInput.focus(),0);
+    }
+    function showMainMenu(){
+      appState='menu';
+      updateVisibility();
+      stopLoop();
+      clearInputs();
+      hideCompletionMenu();
+      overlay('');
+      updateNameDisplays();
+    }
+    function showSettings(){
+      appState='settings';
+      updateVisibility();
+      stopLoop();
+      clearInputs();
+      hideCompletionMenu();
+      overlay('');
+      if(settingsNameInput){settingsNameInput.value=currentPlayerName;setTimeout(()=>settingsNameInput.select(),0);} 
+    }
+    function startGame(){
+      appState='game';
+      updateVisibility();
+      hideCompletionMenu();
+      clearInputs();
+      loadLevel(0);
+      resetToSpawn();
+      updateNameDisplays();
+      draw();
+      updateTimerUI();
+      startLoop();
+    }
+
+    restartBtn.addEventListener('click',()=>{showMainMenu();});
+    menuRestartBtn.addEventListener('click',()=>{showMainMenu();});
+    submitScoreBtn.addEventListener('click',()=>{
       if(timerEnd==null||scoreSubmitted)return;
-      const name=(playerNameInput.value||'').trim()||'Player';
-      pushTime(timerEnd,name);
+      pushTime(timerEnd,currentPlayerName);
       renderLB();
       scoreSubmitted=true;
-      if(submitBtn)submitBtn.disabled=true;
-      playerNameInput.value='';
-      playerNameInput.focus();
+      submitScoreBtn.disabled=true;
+      updateNameDisplays();
     });
-    menuRestartBtn.addEventListener('click',()=>{loadLevel(0);});
-    function init(){renderLB();loadLevel(0);resetToSpawn();requestAnimationFrame(tick);}init();
+    welcomeForm.addEventListener('submit',e=>{
+      e.preventDefault();
+      setPlayerName(welcomeNameInput.value);
+      showMainMenu();
+    });
+    playBtn.addEventListener('click',()=>{startGame();});
+    settingsBtn.addEventListener('click',()=>{showSettings();});
+    settingsForm.addEventListener('submit',e=>{
+      e.preventDefault();
+      setPlayerName(settingsNameInput.value);
+      showMainMenu();
+    });
+    settingsCancelBtn.addEventListener('click',()=>{
+      if(settingsForm)settingsForm.reset();
+      showMainMenu();
+    });
+
+    function init(){
+      updateNameDisplays();
+      renderLB();
+      if(hadStoredName){
+        showMainMenu();
+      }else{
+        showWelcome();
+      }
+    }
+    init();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add welcome, main, and settings overlays so players enter or edit their name before playing
- persist the player name locally and reuse it for leaderboard submissions with the updated completion screen
- introduce menu-driven state management that hides the game outside of play and returns restart actions to the menu

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d0fc732f7083318cb8100928aac01d